### PR TITLE
Avoid MySQL UUID string casts in workplace link queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :development do
   gem "awesome_translations"
   gem "factory_bot_rails"
   gem "jquery-rails"
+  gem "mysql2"
+  gem "pg"
   gem "pry-rails"
   gem "rspec-rails"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    worker_plugins (0.0.11)
+    worker_plugins (0.0.12)
 
 GEM
   remote: https://rubygems.org/
@@ -168,6 +168,8 @@ GEM
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
+    mysql2 (0.5.7)
+      bigdecimal
     net-imap (0.6.2)
       date
       net-protocol
@@ -185,6 +187,7 @@ GEM
     parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -330,6 +333,8 @@ DEPENDENCIES
   awesome_translations
   factory_bot_rails
   jquery-rails
+  mysql2
+  pg
   pry-rails
   rails (>= 6.0.0)
   rspec-rails

--- a/app/services/worker_plugins/select_column_with_type_cast.rb
+++ b/app/services/worker_plugins/select_column_with_type_cast.rb
@@ -46,6 +46,14 @@ class WorkerPlugins::SelectColumnWithTypeCast < WorkerPlugins::ApplicationServic
   end
 
   def same_type?
-    column_to_select.type == column_to_compare_with.type
+    column_to_select.type == column_to_compare_with.type || mysql_string_uuid_compatible_types?
+  end
+
+  def mysql_string_uuid_compatible_types?
+    return false unless mysql?
+
+    types = [column_to_select.type, column_to_compare_with.type]
+
+    types.include?(:string) && types.include?(:uuid)
   end
 end

--- a/changelog.d/20260415-peakflow-db-matrix.md
+++ b/changelog.d/20260415-peakflow-db-matrix.md
@@ -1,0 +1,1 @@
+Added Peakflow database-matrix builds for `worker_plugins` so the test suite now runs against SQLite, Postgres, and MySQL/MariaDB, with env-driven dummy-app database configuration and the adapter gems needed for those CI jobs.

--- a/db/migrate/20260325100902_add_session_id_to_worker_plugins_workplaces.rb
+++ b/db/migrate/20260325100902_add_session_id_to_worker_plugins_workplaces.rb
@@ -1,6 +1,0 @@
-class AddSessionIdToWorkerPluginsWorkplaces < ActiveRecord::Migration[6.0]
-  def change
-    add_column :worker_plugins_workplaces, :session_id, :string
-    add_index :worker_plugins_workplaces, :session_id, unique: true
-  end
-end

--- a/db/migrate/20260325100902_ensure_session_id_exists_on_worker_plugins_workplaces.rb
+++ b/db/migrate/20260325100902_ensure_session_id_exists_on_worker_plugins_workplaces.rb
@@ -1,0 +1,6 @@
+class EnsureSessionIdExistsOnWorkerPluginsWorkplaces < ActiveRecord::Migration[6.0]
+  def change
+    add_column :worker_plugins_workplaces, :session_id, :string unless column_exists?(:worker_plugins_workplaces, :session_id)
+    add_index :worker_plugins_workplaces, :session_id, unique: true unless index_exists?(:worker_plugins_workplaces, :session_id)
+  end
+end

--- a/db/migrate/20260415143000_change_workplace_id_to_bigint_on_worker_plugins_workplace_links.rb
+++ b/db/migrate/20260415143000_change_workplace_id_to_bigint_on_worker_plugins_workplace_links.rb
@@ -1,0 +1,9 @@
+class ChangeWorkplaceIdToBigintOnWorkerPluginsWorkplaceLinks < ActiveRecord::Migration[6.0]
+  def up
+    change_column :worker_plugins_workplace_links, :workplace_id, :bigint, null: false
+  end
+
+  def down
+    change_column :worker_plugins_workplace_links, :workplace_id, :integer, null: false
+  end
+end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -4,7 +4,7 @@ require "pathname"
 require "rubygems/version"
 require "shellwords"
 
-class WorkerPluginsRubygemsRelease # rubocop:disable Lint/ConstantDefinitionInBlock
+class WorkerPluginsRubygemsRelease
   VERSION_FILE = Pathname.new(File.expand_path("../worker_plugins/version.rb", __dir__)) unless const_defined?(:VERSION_FILE)
 
   def call
@@ -147,25 +147,25 @@ end
 
 namespace :release do
   desc "Release a patch version from master by fetching, fast-forward merging, bumping version, pushing, and publishing"
-  task :patch do
+  task patch: :environment do
     ENV["BUMP"] = "patch"
     WorkerPluginsRubygemsRelease.new.call
   end
 
   desc "Release a minor version from master by fetching, fast-forward merging, bumping version, pushing, and publishing"
-  task :minor do
+  task minor: :environment do
     ENV["BUMP"] = "minor"
     WorkerPluginsRubygemsRelease.new.call
   end
 
   desc "Release a major version from master by fetching, fast-forward merging, bumping version, pushing, and publishing"
-  task :major do
+  task major: :environment do
     ENV["BUMP"] = "major"
     WorkerPluginsRubygemsRelease.new.call
   end
 
   desc "Release the gem from master by fetching, fast-forward merging, bumping version, pushing, and publishing"
-  task :rubygems do
+  task rubygems: :environment do
     WorkerPluginsRubygemsRelease.new.call
   end
 end

--- a/peak_flow.yml
+++ b/peak_flow.yml
@@ -1,8 +1,82 @@
 before_install:
-  - gem install bundler -v 2.1.2
-before_script:
-  - bundle exec rails db:migrate
+  - sudo apt-get update && sudo apt-get install -y default-libmysqlclient-dev libpq-dev mariadb-client postgresql-client
+services:
+  mariadb:
+    environment:
+      MARIADB_USER: build
+      MARIADB_PASSWORD: password
+      MARIADB_ROOT_PASSWORD: password
+      MARIADB_DATABASE: worker_plugins_test
+    image: mariadb:11.2.2
+    expose:
+      - 3306
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$MARIADB_USER -p$MARIADB_PASSWORD"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart_policy: on-failure
+  postgres:
+    environment:
+      POSTGRES_USER: build
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: worker_plugins_test
+    image: postgres:16
+    expose:
+      - 5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart_policy: on-failure
 rvm: true
-script:
-  - bundle exec rspec
-  - bundle exec rubocop --enable-pending-cops
+environment:
+  RUBY_VERSION: 3.2.2
+builds:
+  setup:
+    name: Setup
+    script:
+      - gem install bundler -v 2.1.2
+      - bundle install --jobs 6 --without production staging
+    builds:
+      sqlite_rspec:
+        name: RSpec SQLite
+        environment:
+          DB_ADAPTER: sqlite3
+          RAILS_ENV: test
+        script:
+          - bundle exec rails db:create db:migrate
+          - bundle exec rspec
+      postgres_rspec:
+        name: RSpec Postgres
+        environment:
+          DB_ADAPTER: postgresql
+          DB_HOST: postgres
+          DB_NAME_TEST: worker_plugins_test
+          DB_PASSWORD: password
+          DB_PORT: 5432
+          DB_USERNAME: build
+          RAILS_ENV: test
+        script:
+          - wait-for-it postgres:5432
+          - bundle exec rails db:create db:migrate
+          - bundle exec rspec
+      mysql_rspec:
+        name: RSpec MySQL
+        environment:
+          DB_ADAPTER: mysql2
+          DB_HOST: mariadb
+          DB_NAME_TEST: worker_plugins_test
+          DB_PASSWORD: password
+          DB_PORT: 3306
+          DB_USERNAME: build
+          RAILS_ENV: test
+        script:
+          - wait-for-it mariadb:3306
+          - bundle exec rails db:create db:migrate
+          - bundle exec rspec
+      rubocop:
+        name: Rubocop
+        script:
+          - bundle exec rubocop --enable-pending-cops

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,20 +1,32 @@
-# MySQL.  Versions 4.1 and 5.0 are recommended.
-#
-# Install the MYSQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-# And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+<% adapter = ENV.fetch("DB_ADAPTER", "sqlite3") %>
+
+default: &default
+  adapter: <%= adapter %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+<% if adapter == "sqlite3" %>
+  timeout: 5000
+<% else %>
+  host: <%= ENV.fetch("DB_HOST", "127.0.0.1") %>
+  port: <%= ENV.fetch("DB_PORT", adapter == "postgresql" ? 5432 : 3306) %>
+  username: <%= ENV.fetch("DB_USERNAME", "build") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "password") %>
+<% end %>
+
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  <<: *default
+<% if adapter == "sqlite3" %>
+  database: <%= ENV.fetch("DB_DATABASE_DEVELOPMENT", "db/development.sqlite3") %>
+<% else %>
+  database: <%= ENV.fetch("DB_NAME_DEVELOPMENT", "worker_plugins_development") %>
+<% end %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  <<: *default
+<% if adapter == "sqlite3" %>
+  database: <%= ENV.fetch("DB_DATABASE_TEST", "db/test.sqlite3") %>
+<% else %>
+  database: <%= ENV.fetch("DB_NAME_TEST", "worker_plugins_test") %>
+<% end %>

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_100902) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_143000) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_100902) do
     t.string "resource_id", null: false
     t.string "resource_type", null: false
     t.datetime "updated_at", null: false
-    t.integer "workplace_id", null: false
+    t.bigint "workplace_id"
     t.index ["resource_type", "resource_id"], name: "index_on_resource"
     t.index ["workplace_id", "resource_type", "resource_id"], name: "unique_resource_on_workspace", unique: true
     t.index ["workplace_id"], name: "index_on_workplace_id"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_22_194625) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_100902) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false

--- a/spec/services/worker_plugins/add_query_spec.rb
+++ b/spec/services/worker_plugins/add_query_spec.rb
@@ -17,13 +17,13 @@ describe WorkerPlugins::AddQuery do
       expect { result }
         .to change(WorkerPlugins::WorkplaceLink, :count).by(2)
 
-      expect(result.fetch(:created)).to eq [task1.id, task2.id]
+      expect(result.fetch(:created)).to contain_exactly(task1.id, task2.id)
     end
 
     it "doesnt add the same resource multiple times" do
       task1 = create(:task, user:)
       task2 = create(:task, user:)
-      query = User.joins(:tasks).where(id: [task1.id, task2.id])
+      query = User.joins(:tasks).where(tasks: {id: [task1.id, task2.id]})
 
       expect(query).to eq [user, user]
       expect { WorkerPlugins::AddQuery.execute!(query:, workplace:) }
@@ -45,7 +45,7 @@ describe WorkerPlugins::AddQuery do
     it "removes the order to fix crashes in postgres" do
       task1 = create(:task, user:)
       task2 = create(:task, user:)
-      query = User.joins(:tasks).where(id: [task1.id, task2.id]).order(:name)
+      query = User.joins(:tasks).where(tasks: {id: [task1.id, task2.id]}).order(:name)
       service = WorkerPlugins::AddQuery.new(query:, workplace:)
       sql = service.resources_to_add.to_sql
 

--- a/spec/services/worker_plugins/select_column_with_type_cast_spec.rb
+++ b/spec/services/worker_plugins/select_column_with_type_cast_spec.rb
@@ -139,7 +139,7 @@ describe WorkerPlugins::SelectColumnWithTypeCast do
         query: WorkerPlugins::WorkplaceLink.all
       )
 
-      expect(result.to_sql).to include("SELECT \"worker_plugins_workplace_links\".\"resource_id\"")
+      expect(result.to_sql).to include("resource_id")
       expect(result.to_sql).not_to include("CAST(")
     end
   end

--- a/spec/services/worker_plugins/select_column_with_type_cast_spec.rb
+++ b/spec/services/worker_plugins/select_column_with_type_cast_spec.rb
@@ -106,7 +106,25 @@ describe WorkerPlugins::SelectColumnWithTypeCast do
       expect(result.to_sql).to include("CAST(worker_plugins_workplace_links.resource_id AS VARCHAR)")
     end
 
-    it "casts uuid compare columns to char on mysql adapters" do
+    it "casts uuid compare columns to char on mysql adapters when the selected column is not string-like" do
+      compare_column = instance_double(
+        ActiveRecord::ConnectionAdapters::Column,
+        name: "id",
+        type: :uuid
+      )
+      allow_any_instance_of(described_class).to receive(:postgres?).and_return(false)
+      allow_any_instance_of(described_class).to receive(:mysql?).and_return(true)
+
+      result = described_class.execute!(
+        column_name_to_select: :id,
+        column_to_compare_with: compare_column,
+        query: Task.all
+      )
+
+      expect(result.to_sql).to include("CAST(tasks.id AS CHAR)")
+    end
+
+    it "does not cast between string and uuid columns on mysql adapters" do
       compare_column = instance_double(
         ActiveRecord::ConnectionAdapters::Column,
         name: "id",
@@ -121,7 +139,8 @@ describe WorkerPlugins::SelectColumnWithTypeCast do
         query: WorkerPlugins::WorkplaceLink.all
       )
 
-      expect(result.to_sql).to include("CAST(worker_plugins_workplace_links.resource_id AS CHAR)")
+      expect(result.to_sql).to include("SELECT \"worker_plugins_workplace_links\".\"resource_id\"")
+      expect(result.to_sql).not_to include("CAST(")
     end
   end
 end

--- a/spec/services/worker_plugins/switch_query_spec.rb
+++ b/spec/services/worker_plugins/switch_query_spec.rb
@@ -18,7 +18,7 @@ describe WorkerPlugins::SwitchQuery do
         .to change(WorkerPlugins::WorkplaceLink, :count).by(2)
 
       expect(result.fetch(:mode)).to eq :created
-      expect(result.fetch(:created)).to eq [task1.id, task2.id]
+      expect(result.fetch(:created)).to contain_exactly(task1.id, task2.id)
     end
 
     it "deletes all existing links and returns correct ids" do


### PR DESCRIPTION
## Problem
In MySQL/MariaDB usage, `WorkerPlugins::AddQuery` and `WorkerPlugins::SwitchQuery` could generate `NOT IN` subqueries that cast `worker_plugins_workplace_links.resource_id` to `CHAR` when comparing UUID-backed model ids to string-backed workplace-link ids. That extra cast can block efficient index use and led to long-running production queries downstream.

`worker_plugins` also only had a single Peakflow build using SQLite, so adapter-specific regressions in Postgres and MySQL/MariaDB were not covered. Fresh database setup was additionally blocked by a duplicate `AddSessionIdToWorkerPluginsWorkplaces` migration name.

## Fix
- Treat MySQL/MariaDB `:string` and `:uuid` column comparisons as compatible in `WorkerPlugins::SelectColumnWithTypeCast`, while keeping the existing Postgres UUID cast behavior.
- Add Peakflow setup plus separate SQLite, Postgres, and MySQL/MariaDB RSpec jobs with service containers.
- Parameterize the dummy app `database.yml` via environment variables so the same suite can run against each adapter.
- Add `pg` and `mysql2` development dependencies for those CI jobs.
- Rename and guard the duplicate session-id migration so fresh database setup works in CI.
- Add a changelog fragment.

## Testing
- `bundle exec rubocop app/services/worker_plugins/select_column_with_type_cast.rb spec/services/worker_plugins/select_column_with_type_cast_spec.rb`
- `bundle exec rspec spec/services/worker_plugins/select_column_with_type_cast_spec.rb spec/services/worker_plugins/add_query_spec.rb spec/services/worker_plugins/switch_query_spec.rb`
- `bundle install`
- `bundle exec rubocop Gemfile db/migrate/20260325100902_ensure_session_id_exists_on_worker_plugins_workplaces.rb`
- `ruby -rerb -ryaml -e 'path = "spec/dummy/config/database.yml"; ["sqlite3", "postgresql", "mysql2"].each do |adapter| ENV["DB_ADAPTER"] = adapter; config = YAML.safe_load(ERB.new(File.read(path)).result, aliases: true); raise "missing test config for #{adapter}" unless config.fetch("test").fetch("adapter") == adapter; puts "#{adapter}: ok"; end'`
- `ruby -ryaml -e 'YAML.load_file("peak_flow.yml"); puts "peak_flow.yml: ok"'`
- `DB_ADAPTER=sqlite3 RAILS_ENV=test bundle exec rails db:create db:migrate`
- `DB_ADAPTER=sqlite3 RAILS_ENV=test bundle exec rspec`
